### PR TITLE
update jfrog cli repo url

### DIFF
--- a/cmd/publish_to_artifactory.go
+++ b/cmd/publish_to_artifactory.go
@@ -48,7 +48,7 @@ func (cmd *publishToArtifactoryCmd) Execute() {
 
 	cmd.EvalCurrentAndNextVersion()
 
-	cmd.runCommand("install jfrog cli", "go", "get", "github.com/jfrog/jfrog-cli-go/...")
+	cmd.runCommand("install jfrog cli", "go", "get", "github.com/jfrog/jfrog-cli/...")
 	releaseDir, err := filepath.Abs("./release")
 	cmd.exitIfErrf(err, "could not get absolute path for releases directory")
 


### PR DESCRIPTION
It appears this project changed its repo URL.

https://github.com/jfrog/jfrog-cli/commit/54a1635561b558da866e002792a86f9d148782e6