### PR TITLE
adds support for running within git worktrees

### DIFF
--- a/cmd/build_release_notes.go
+++ b/cmd/build_release_notes.go
@@ -178,9 +178,11 @@ func (cmd *baseBuildReleaseNotesCmd) GetChanges(project string, oldVersion strin
 		return errors.Wrapf(err, "")
 	}
 
-	cmd.runGitCommandAlways("fetch latest tags", "fetch", "--tags")
+	if !cmd.noFetch {
+		cmd.runGitCommandAlways("fetch latest tags", "fetch", "--tags")
+	}
 
-	r, err := git.PlainOpen(".")
+	r, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{EnableDotGitCommonDir: true})
 	if err != nil {
 		return err
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -147,7 +147,9 @@ func (cmd *BaseCommand) GetCobraCmd() *cobra.Command {
 }
 
 func (cmd *BaseCommand) EvalCurrentAndNextVersion() {
-	cmd.runGitCommandAlways("fetching git tags", "fetch", "--tags", "--force")
+	if !cmd.noFetch {
+		cmd.runGitCommandAlways("fetching git tags", "fetch", "--tags", "--force")
+	}
 	versions := cmd.getVersionList("tag", "--list")
 
 	min := setPatch(cmd.BaseVersion, 0)

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -40,6 +40,7 @@ type RootCommand struct {
 	useCurrentTag bool
 	dryRun        bool
 	quiet         bool
+	noFetch       bool
 
 	langName string
 	lang     langType
@@ -66,6 +67,7 @@ func newRootCommand() *RootCommand {
 
 	cobraCmd.PersistentFlags().StringVarP(&rootCmd.baseVersionString, "base-version", "b", "", "set base version")
 	cobraCmd.PersistentFlags().StringVarP(&rootCmd.baseVersionFile, "base-version-file", "f", DefaultVersionFile, "set base version file location")
+	cobraCmd.PersistentFlags().BoolVar(&rootCmd.noFetch, "no-fetch", false, "skip git fetch --tags (useful when running locally with SSH agent issues)")
 
 	rootCobraCmd := rootCmd.RootCobraCmd
 


### PR DESCRIPTION
- use EnableDotGitCommonDir, which in non-worktrees will short circuit to normal logic, but in worktrees will point to the correct gitdir
- also adds `--no-fetch` to allow skipping tag fetching in git when tags have already been fetched or when debugging and child git/ssh processes won't interact with GPG Agents correctly